### PR TITLE
Add missing ability for DateRangePicker to be customised in Filter

### DIFF
--- a/src/components/Filter/index.js
+++ b/src/components/Filter/index.js
@@ -60,6 +60,7 @@ class Filter extends React.Component<PropsType> {
       loading: false,
     },
     PredefinedFilterComponent: PredefinedFilter,
+    DateRangePickerComponent: DateRangePicker,
   };
 
   defaultProps: DefaultPropsType;
@@ -192,6 +193,7 @@ class Filter extends React.Component<PropsType> {
       groupSelection,
       datePickerLabel,
       PredefinedFilterComponent,
+      DateRangePickerComponent,
     } = this.props;
     return (
       <div className={baseClass}>
@@ -251,8 +253,10 @@ class Filter extends React.Component<PropsType> {
             <label htmlFor="_" className="form__label--small">
               {datePickerLabel}
             </label>
-            <div className={`${baseClass}__item__input push--small--bottom`}>
-              <DateRangePicker datepickerChanged={this.datepickerChanged} />
+            <div className={`${baseClass}__item__input`}>
+              <DateRangePickerComponent
+                datepickerChanged={this.datepickerChanged}
+              />
             </div>
           </div>
         ) : null}
@@ -261,7 +265,7 @@ class Filter extends React.Component<PropsType> {
             <label htmlFor="_" className="form__label--small">
               {groupSelectionLabel}
             </label>
-            <div className={`${baseClass}__item__input push--small--bottom`}>
+            <div className={`${baseClass}__item__input`}>
               <SimpleSelect
                 onChange={this.updateGrouping}
                 value={this.state.grouping}


### PR DESCRIPTION
## Proposed changes
- custom labels and placeholders are instrumental in making this component cross-project, we simply removed opinionated classes and allow a custom version of the component to be passed into the Filter

## Types of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] New feature
- [x] Bugfix
- [ ] Quality of Life

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Linter passes (`yarn lint`)
- [ ] Unit Test pass (`yarn jest`)
- [ ] I have added at least two useful tests for new component (if applicable)
- [ ] I have added at least one Storybook story (if applicable)

## Relevant Issues

_List Issues below in format `#<ISSUE-NUMBER> [Full|Partial]`_
- see: https://github.com/sensational/offer-marketplace/pull/3215#pullrequestreview-305081817

## Dependant PRs

_List Pull Requests below in format `#<ISSUE-NUMBER>`_
- ...

## Description

_If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc._

