### PR TITLE
Support RowIndex in SimpleItem

### DIFF
--- a/src/components/SimpleList/components/Body.js
+++ b/src/components/SimpleList/components/Body.js
@@ -36,9 +36,10 @@ const Body = ({
                 {headings.map((col: Object, ck: number): React$Element<*> => (
                   <SimpleItemComponent
                     key={`${ck}`}
+                    rowIndex={vk}
                     row={v}
                     text={v[col.name]}
-                    flex={`${(1 / headings.length) * 100}%`}
+                    flex={`${col.flex || (1 / headings.length) * 100}%`}
                     align={col.align}
                     column={col.name}
                     itemClass="simple-list__body__row__item"

--- a/src/components/SimpleList/components/Body.js
+++ b/src/components/SimpleList/components/Body.js
@@ -5,6 +5,7 @@ import SimpleListContext from '../context';
 import ButtonOrDiv from './ButtonOrDiv';
 
 const Body = ({
+  SimpleRowComponent = ButtonOrDiv,
   SimpleItemComponent = SimpleListItem,
   PaginatorComponent = Paginator,
 }) => {
@@ -26,7 +27,7 @@ const Body = ({
         {typeof childrenRenderer === 'function'
           ? childrenRenderer(data)
           : data.map((v: Object, vk: number): React$Element<*> => (
-              <ButtonOrDiv
+              <SimpleRowComponent
                 key={vk}
                 allowClick={allowClick}
                 index={vk}
@@ -36,7 +37,6 @@ const Body = ({
                 {headings.map((col: Object, ck: number): React$Element<*> => (
                   <SimpleItemComponent
                     key={`${ck}`}
-                    rowIndex={vk}
                     row={v}
                     text={v[col.name]}
                     flex={`${col.flex || (1 / headings.length) * 100}%`}
@@ -47,7 +47,7 @@ const Body = ({
                     customRenderer={col.customRenderer || null}
                   />
                 ))}
-              </ButtonOrDiv>
+              </SimpleRowComponent>
             ))}
       </div>
 

--- a/src/components/SimpleList/components/ButtonOrDiv.js
+++ b/src/components/SimpleList/components/ButtonOrDiv.js
@@ -31,7 +31,8 @@ const ButtonOrDiv = ({
     </button>
   ) : (
     <div
-      className={`${baseClass}${index % 2 ? '--bgc-alt' : ''} disable-hover`}>
+      data-qe-id={identifier}
+      className={`${baseClass}${index % 2 ? '--bgc-alt' : ''}`}>
       {children}
     </div>
   );

--- a/src/components/SimpleList/components/SimpleItem.js
+++ b/src/components/SimpleList/components/SimpleItem.js
@@ -1,12 +1,13 @@
 import React from 'react';
 
-type Formatter = (itemValue: any) => any;
-
 type ItemRenderer = (
   itemValue: any,
   columnName: string,
   rowData: Object,
+  rowIndex: number,
 ) => any;
+
+type Formatter = ItemRenderer;
 
 type SimpleListItemShape = {
   text?: string | number | Array<*>,
@@ -16,6 +17,7 @@ type SimpleListItemShape = {
   itemClass?: string,
   customFormatter?: Function,
   customRenderer?: ItemRenderer,
+  rowIndex: number,
 };
 
 const getItem = (
@@ -24,12 +26,13 @@ const getItem = (
   rowData: Object,
   formatter: Formatter,
   renderer: ItemRenderer,
+  rowIndex: number,
 ) => {
   if (renderer) {
-    return renderer(itemValue, rowData, columnName);
+    return renderer(itemValue, rowData, columnName, rowIndex);
   }
   if (formatter) {
-    return formatter(itemValue, rowData, columnName);
+    return formatter(itemValue, rowData, columnName, rowIndex);
   }
   return itemValue;
 };
@@ -40,6 +43,7 @@ const SimpleListItem = ({
   flex,
   align,
   column,
+  rowIndex,
   itemClass,
   customFormatter,
   customRenderer,
@@ -52,7 +56,7 @@ const SimpleListItem = ({
       maxWidth: flex,
       flexBasis: flex,
     }}>
-    {getItem(column, text, row, customFormatter, customRenderer)}
+    {getItem(column, text, row, customFormatter, customRenderer, rowIndex)}
   </span>
 );
 

--- a/src/components/SimpleList/components/SimpleItem.js
+++ b/src/components/SimpleList/components/SimpleItem.js
@@ -4,7 +4,6 @@ type ItemRenderer = (
   itemValue: any,
   columnName: string,
   rowData: Object,
-  rowIndex: number,
 ) => any;
 
 type Formatter = ItemRenderer;
@@ -17,7 +16,6 @@ type SimpleListItemShape = {
   itemClass?: string,
   customFormatter?: Function,
   customRenderer?: ItemRenderer,
-  rowIndex: number,
 };
 
 const getItem = (
@@ -26,13 +24,12 @@ const getItem = (
   rowData: Object,
   formatter: Formatter,
   renderer: ItemRenderer,
-  rowIndex: number,
 ) => {
   if (renderer) {
-    return renderer(itemValue, rowData, columnName, rowIndex);
+    return renderer(itemValue, rowData, columnName);
   }
   if (formatter) {
-    return formatter(itemValue, rowData, columnName, rowIndex);
+    return formatter(itemValue, rowData, columnName);
   }
   return itemValue;
 };
@@ -43,7 +40,6 @@ const SimpleListItem = ({
   flex,
   align,
   column,
-  rowIndex,
   itemClass,
   customFormatter,
   customRenderer,
@@ -56,7 +52,7 @@ const SimpleListItem = ({
       maxWidth: flex,
       flexBasis: flex,
     }}>
-    {getItem(column, text, row, customFormatter, customRenderer, rowIndex)}
+    {getItem(column, text, row, customFormatter, customRenderer)}
   </span>
 );
 


### PR DESCRIPTION
## Proposed changes
- Support customisable Row component inside SimpleList
- ~SimpleItem now accepts `rowIndex` property~
- SimpleItem now uses Headers->`flex` property by default

~rowIndex is useful for identifying the row of the Item, this can be used for testing when getting a row item by rowIndex. (Note: this is a requirement for Asset/House/Property lists)~

headers->flex property can be used customising the width of columns

## Types of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] New feature
- [ ] Bugfix
- [ ] Quality of Life

## Checklist

_Put an `x` in the boxes that apply._

- [x] Linter passes (`yarn lint`)
- [x] Unit Test pass (`yarn jest`)
- [ ] I have added at least two useful tests for new component (if applicable)
- [ ] I have added at least one Storybook story (if applicable)

## Relevant Issues

_List Issues below in format `#<ISSUE-NUMBER> [Full|Partial]`_
- ...

## Dependant PRs

_List Pull Requests below in format `#<ISSUE-NUMBER>`_
- ...

## Description

_If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc._

